### PR TITLE
fix(create-robo): package manager run prefix

### DIFF
--- a/packages/create-robo/src/robo.ts
+++ b/packages/create-robo/src/robo.ts
@@ -323,7 +323,7 @@ export default class Robo {
 			await fs.writeFile(path.join(this._workingDir, 'README.md'), customReadme)
 		}
 
-		const runPrefix = packageManager + packageManager === 'npm' ? 'npm run ' : packageManager + ' '
+		const runPrefix = packageManager === 'npm' ? 'npm run ' : packageManager + ' '
 		if (this._useTypeScript) {
 			packageJson.devDependencies['@swc/core'] = '^1.3.44'
 			packageJson.devDependencies['@types/node'] = '^18.14.6'


### PR DESCRIPTION
otherwise it shows this using npm,

![image](https://github.com/Wave-Play/robo.js/assets/69188140/4ded1538-3966-43a0-a989-4ea288bd3ab2)
