### PR TITLE
feat(core): experimental sharding support

### DIFF
--- a/.changeset/chatty-crews-bake.md
+++ b/.changeset/chatty-crews-bake.md
@@ -1,0 +1,5 @@
+---
+'robo.js': patch
+---
+
+refactor(core): moved data loading into robo.start() in production mode

--- a/.changeset/cuddly-bulldogs-hug.md
+++ b/.changeset/cuddly-bulldogs-hug.md
@@ -1,0 +1,5 @@
+---
+'robo.js': patch
+---
+
+feat: experimental sharding support

--- a/docs/docs/robojs/config.md
+++ b/docs/docs/robojs/config.md
@@ -101,6 +101,7 @@ Activate experimental features or revert to older behaviors for compatibility. T
 - `buildDirectory`: Determine where to compile your code. The default is `.robo/build`, but you can specify another location.
 - `disableBot`: Turn off bot features, allowing you to run Robo.js without a bot.
 - `incrementalBuilds`: Enable incremental builds to improve build performance by only recompiling changed files.
+- `shard`: Enable sharding support. Can be `true` or a `ShardingManagerOptions` object.
 - `userInstall`: Optimize command registration for user-installed apps.
 
 ```js
@@ -108,6 +109,7 @@ experimental: {
 	buildDirectory: 'dist',
 	disableBot: true,
 	incrementalBuilds: true,
+	shard: true,
 	userInstall: true
 }
 ```

--- a/packages/robo/package.json
+++ b/packages/robo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "robo.js",
-	"version": "0.10.9-dev",
+	"version": "0.10.9",
 	"private": false,
 	"description": "Power up Discord with effortless activities, bots, web servers, and more!",
 	"keywords": [

--- a/packages/robo/package.json
+++ b/packages/robo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "robo.js",
-	"version": "0.10.9",
+	"version": "0.10.9-dev",
 	"private": false,
 	"description": "Power up Discord with effortless activities, bots, web servers, and more!",
 	"keywords": [

--- a/packages/robo/src/cli/commands/start.ts
+++ b/packages/robo/src/cli/commands/start.ts
@@ -5,9 +5,7 @@ import { logger } from '../../core/logger.js'
 import { hasFilesRecursively } from '../utils/fs-helper.js'
 import { color, composeColors } from '../../core/color.js'
 import { loadConfig } from '../../core/config.js'
-import { Flashcore, prepareFlashcore } from '../../core/flashcore.js'
-import { FLASHCORE_KEYS, Indent } from '../../core/constants.js'
-import { loadState } from '../../core/state.js'
+import { Indent } from '../../core/constants.js'
 
 const command = new Command('start')
 	.description('Starts your bot in production mode.')
@@ -57,12 +55,10 @@ async function startAction(_args: string[], options: StartCommandOptions) {
 		await fs.access(path.join('.robo', 'manifest.json'))
 	} catch (err) {
 		logger.error(
-			`The ${color.bold(
-				'.robo/manifest.json'
-			)} file is missing. Make sure your project structure is correct and run ${composeColors(
+			`The manifest file is missing. Make sure your project structure is correct and run ${composeColors(
 				color.bold,
-				color.blue
-			)('"robo build"')} again.`
+				color.cyan
+			)('robo build')} again.`
 		)
 		process.exit(1)
 	}
@@ -77,27 +73,7 @@ async function startAction(_args: string[], options: StartCommandOptions) {
 		logger.warn(`Experimental flags enabled: ${features}.`)
 	}
 
-	// Load state from Flashcore
-	const stateStart = Date.now()
-	const stateLoadPromise = new Promise<void>((resolve) => {
-		async function load() {
-			await prepareFlashcore()
-			const state = await Flashcore.get<Record<string, unknown>>(FLASHCORE_KEYS.state)
-			if (state) {
-				loadState(state)
-			}
-
-			logger.debug(`State loaded in ${Date.now() - stateStart}ms`)
-			resolve()
-		}
-		load()
-	})
-
-	// Imported dynamically to prevent multiple process hooks
+	// Start Roboooooooo!! :D (dynamic to avoid premature process hooks)
 	const { Robo } = await import('../../core/robo.js')
-
-	// Start Roboooooooo!! :D
-	Robo.start({
-		stateLoad: stateLoadPromise
-	})
+	Robo.start()
 }

--- a/packages/robo/src/cli/commands/start.ts
+++ b/packages/robo/src/cli/commands/start.ts
@@ -75,5 +75,7 @@ async function startAction(_args: string[], options: StartCommandOptions) {
 
 	// Start Roboooooooo!! :D (dynamic to avoid premature process hooks)
 	const { Robo } = await import('../../core/robo.js')
-	Robo.start()
+	Robo.start({
+		shard: !!config.experimental?.shard
+	})
 }

--- a/packages/robo/src/cli/shard.ts
+++ b/packages/robo/src/cli/shard.ts
@@ -1,0 +1,3 @@
+process.removeAllListeners('warning')
+import { Robo } from '../core/robo.js'
+Robo.start()

--- a/packages/robo/src/cli/utils/utils.ts
+++ b/packages/robo/src/cli/utils/utils.ts
@@ -14,6 +14,7 @@ import { IS_BUN } from './runtime-utils.js'
 import type { Pod } from '../../roboplay/types.js'
 
 export const __DIRNAME = path.dirname(fileURLToPath(import.meta.url))
+export const PackageDir = path.resolve(__DIRNAME, '..', '..', '..')
 
 const execAsync = promisify(nodeExec)
 

--- a/packages/robo/src/types/config.ts
+++ b/packages/robo/src/types/config.ts
@@ -1,5 +1,5 @@
 import type { LogDrain, LogLevel } from '../core/logger.js'
-import type { ClientOptions, PermissionsString } from 'discord.js'
+import type { ClientOptions, PermissionsString, ShardingManagerOptions } from 'discord.js'
 import type { Plugin, SageOptions } from './index.js'
 
 export interface Config {
@@ -13,6 +13,7 @@ export interface Config {
 		buildDirectory?: string
 		disableBot?: boolean
 		incrementalBuilds?: boolean
+		shard?: boolean | ShardingManagerOptions
 		userInstall?: boolean
 	}
 	flashcore?: {


### PR DESCRIPTION
Adds experimental support for sharding bots via the `ShardingManager` provided by Discord.js.

This was previously only available via the not-so-recommended `shards: 'auto'` client option.