### PR TITLE
fix(cli): cli break when file deleted

### DIFF
--- a/packages/robo/src/cli/utils/watcher.ts
+++ b/packages/robo/src/cli/utils/watcher.ts
@@ -32,7 +32,7 @@ export default class Watcher {
 	private debouncer: Debouncer
 
 	// Initialize with paths to watch and options.
-	constructor(private paths: string[], private options: Options) {}
+	constructor(private paths: string[], private options: Options) { }
 
 	// Start the watcher. Files are read, and callbacks are set up.
 	async start(callback: (changes: Change[]) => Promise<void>) {
@@ -172,7 +172,15 @@ export default class Watcher {
 				}
 			} else if (event === 'change') {
 				// If the file changed, check the modification time and trigger the callback if it's a new change.
-				const stat = await fs.lstat(filePath)
+				const stat = await fs.lstat(filePath).catch(e => {
+					if (e.message.startsWith('ENOENT')) {
+						this.watchedFiles.delete(filePath)
+						return null;
+					} else {
+						throw e
+					}
+				})
+				if (!stat) return;
 				if (this.watchedFiles.get(filePath)?.getTime() !== stat.mtime.getTime()) {
 					this.watchedFiles.set(filePath, stat.mtime)
 					if (!this.isFirstTime) {


### PR DESCRIPTION
### before, error when any file delete causing dev cmd to break

![watcher js - rbj  Codespaces_ musical space dollop  - Visual Studio Code — Zen Browser 10_12_2024 1_10_37 AM](https://github.com/user-attachments/assets/07a8f0c1-85d3-4be9-ab44-eecc805a47ed)
