### PR TITLE
fix(core/env): loadEnv was commented

### DIFF
--- a/.changeset/olive-cycles-clean.md
+++ b/.changeset/olive-cycles-clean.md
@@ -1,0 +1,5 @@
+---
+'robo.js': patch
+---
+
+patch: Fix broken invite command.

--- a/packages/robo/src/core/env.ts
+++ b/packages/robo/src/core/env.ts
@@ -1,5 +1,5 @@
-//import { loadEnv } from './dotenv.js'
-//loadEnv({ sync: true })
+import { loadEnv } from './dotenv.js'
+loadEnv({ sync: true })
 
 const Keys = {
 	discord: {
@@ -25,7 +25,7 @@ const Keys = {
 
 export const env = (key: string): string => {
 	const keyParts = key.split('.')
-
+	
 	return keyParts.reduce((acc, k) => {
 		// @ts-expect-error - ...
 		const value = acc[k]

--- a/packages/robo/src/core/env.ts
+++ b/packages/robo/src/core/env.ts
@@ -1,5 +1,4 @@
 import { loadEnv } from './dotenv.js'
-loadEnv({ sync: true })
 
 const Keys = {
 	discord: {
@@ -24,6 +23,8 @@ const Keys = {
 }
 
 export const env = (key: string): string => {
+	loadEnv({ sync: true })
+
 	const keyParts = key.split('.')
 	
 	return keyParts.reduce((acc, k) => {


### PR DESCRIPTION
Hii, our users had issues running the invite command for some reasons the env loading was commented out, is there any reasons for it (thats why I made a PR and not commited directly)

** a patch is included **