### PR TITLE
robo Command Not Found When Starting robo-server

### DIFF
--- a/docs/src/App.jsx
+++ b/docs/src/App.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { SyncProvider } from '@robojs/sync'
+import { MultiplayerGame } from './components/MultiplayerGame' // Adjust path if needed
+
+function App() {
+	return (
+		<SyncProvider>
+			<MultiplayerGame />
+		</SyncProvider>
+	)
+}
+
+export default App

--- a/docs/src/components/GameBoard.jsx
+++ b/docs/src/components/GameBoard.jsx
@@ -1,0 +1,15 @@
+// src/components/GameBoard.jsx
+import React from 'react'
+
+const GameBoard = ({ state, onAction }) => {
+	// Render the game board based on the state
+	return (
+		<div>
+			{/* Render game elements based on state */}
+			<h1>Game Board</h1>
+			<button onClick={() => onAction({ type: 'SOME_ACTION' })}>Perform Action</button>
+		</div>
+	)
+}
+
+export default GameBoard

--- a/docs/src/components/MultiplayerGame.jsx
+++ b/docs/src/components/MultiplayerGame.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect } from 'react'
+import { useSyncState, useSyncBroadcast, useSyncContext } from '@robojs/sync'
+import GameBoard from './GameBoard' // Ensure you import GameBoard
+
+export function MultiplayerGame() {
+	const initialGameState = {
+		players: []
+		// Add other game state properties as needed
+	}
+
+	const [gameState, setGameState, syncContext] = useSyncState(initialGameState, ['gameRoom'])
+	const { clients, clientId, isHost } = syncContext
+
+	const { broadcast } = useSyncBroadcast(
+		(action, context) => {
+			console.log(`${context.clientId} performed action: `, action)
+			setGameState((prevState) => ({ ...prevState, ...action }))
+		},
+		['gameRoom']
+	)
+
+	useSyncContext(
+		{
+			onConnect: (client) => console.log(`${client.id} has joined`),
+			onDisconnect: (client) => console.log(`${client.id} has left`)
+		},
+		['gameRoom']
+	)
+
+	useEffect(() => {
+		if (isHost) {
+			console.log('You are the host!')
+		}
+	}, [isHost])
+
+	const handlePlayerAction = (action) => {
+		setGameState((prevState) => ({ ...prevState, ...action }))
+		broadcast(action)
+	}
+
+	return (
+		<div>
+			<GameBoard state={gameState} onAction={handlePlayerAction} />
+			<div>Connected Players: {clients.length}</div>
+		</div>
+	)
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
 	"name": "robo",
 	"version": "0.0.0",
+	"bin": {
+		"create-robo": "./bin/create-robo.js"
+	},
 	"private": true,
 	"workspaces": {
 		"packages": [


### PR DESCRIPTION
Description

When running pnpm run start in the robo-server directory, I get the error:

sh: 1: robo: not found
ELIFECYCLE Command failed.
WARN Local package.json exists, but node_modules missing, did you mean to install?

Steps to Reproduce

    Navigate to the directory:

Run:

pnpm run start


Troubleshooting Steps

    * Checked for node_modules (missing).
    * Ran pnpm install.
    * Confirmed @robojs/cli is in package.json.
    * Tried installing globally: pnpm add -g @robojs/cli.
    * Unable to run robo-version.