### PR TITLE
Make multi-arg options optional

### DIFF
--- a/packages/robo/__tests__/cli-handler.test.ts
+++ b/packages/robo/__tests__/cli-handler.test.ts
@@ -1,0 +1,14 @@
+import { Command } from '../src/cli/utils/cli-handler'
+
+describe('CLI Handler Tests', () => {
+	it('should assign only a single argument to -k option', () => {
+		const command = new Command('test-command')
+		command.option('-k', '--kit', 'Test option')
+
+		const args = ['-k', 'activity', 'myactivity']
+		const parsedOptions = command['parseOptions'](args)
+
+		expect(parsedOptions.kit).toBe('activity')
+		expect(args).toContain('myactivity')
+	})
+})

--- a/packages/robo/src/cli/utils/cli-handler.ts
+++ b/packages/robo/src/cli/utils/cli-handler.ts
@@ -200,13 +200,8 @@ export class Command {
 				const option = this._options.find((opt) => opt.name === arg)
 				if (option) {
 					if (this._allowSpacesInOptions && i + 1 < args.length && !args[i + 1].startsWith('-')) {
-						let value = args[i + 1]
-						i += 2 // Move past the option and its value
-						while (i < args.length && !args[i].startsWith('-')) {
-							value += ` ${args[i]}`
-							i++
-						}
-						options[arg.slice(2)] = value
+						options[arg.slice(2)] = args[i + 1]
+						i += 2 // Skip over option and its single value
 					} else {
 						options[arg.slice(2)] = true
 						i++
@@ -218,13 +213,8 @@ export class Command {
 				const option = this._options.find((opt) => opt.alias === arg)
 				if (option) {
 					if (this._allowSpacesInOptions && i + 1 < args.length && !args[i + 1].startsWith('-')) {
-						let value = args[i + 1]
-						i += 2 // Move past the option and its value
-						while (i < args.length && !args[i].startsWith('-')) {
-							value += ` ${args[i]}`
-							i++
-						}
-						options[option.name.slice(2)] = value
+						options[option.name.slice(2)] = args[i + 1]
+						i += 2 // Skip over option and its single value
 					} else {
 						options[option.name.slice(2)] = true
 						i++
@@ -233,7 +223,7 @@ export class Command {
 					i++
 				}
 			} else {
-				i++
+				break // Stop capturing once positional arguments start
 			}
 		}
 


### PR DESCRIPTION
Fixes #331 Updates the CLI handler to make multi-argument options optional. This change prevents single-value options, like `-k` or `--kit`, from capturing unintended positional arguments. Only one value is assigned to options, leaving other arguments as positional. Additionally, a unit test has been added to verify this behavior.

#### Test:
```typescript
import { Command } from '../src/cli/utils/cli-handler'

describe('CLI Handler Tests', () => {
	it('should assign only a single argument to -k option', () => {
		const command = new Command('test-command')
		command.option('-k', '--kit', 'Test option')

		const args = ['-k', 'activity', 'myactivity']
		const parsedOptions = command['parseOptions'](args)

		expect(parsedOptions.kit).toBe('activity')
		expect(args).toContain('myactivity')
	})
})

```

#### Test result:
```bash
npx jest cli-handler.test.ts
 PASS  __tests__/cli-handler.test.ts
  CLI Handler Tests
    ✓ should assign only a single argument to -k option (2 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        2.249 s
Ran all test suites matching /cli-handler.test.ts/i.

```