### PR TITLE
patch(create-robo): skip discord credentials when setting up with the web kit

### DIFF
--- a/packages/create-robo/src/index.ts
+++ b/packages/create-robo/src/index.ts
@@ -226,7 +226,7 @@ new Command('create-robo <projectName>')
 
 		// Ask the user for their Discord credentials (token and client ID) and store them for later use
 		// Skip this step if the user is creating a plugin
-		if (!robo.isPlugin && !(options.kit === 'web')) {
+		if (!robo.isPlugin && options.kit !== 'web') {
 			logger.debug(`Asking for Discord credentials...`)
 			await robo.askForDiscordCredentials()
 		}

--- a/packages/create-robo/src/index.ts
+++ b/packages/create-robo/src/index.ts
@@ -226,7 +226,7 @@ new Command('create-robo <projectName>')
 
 		// Ask the user for their Discord credentials (token and client ID) and store them for later use
 		// Skip this step if the user is creating a plugin
-		if (!robo.isPlugin) {
+		if (!robo.isPlugin && !(options.kit === 'web')) {
 			logger.debug(`Asking for Discord credentials...`)
 			await robo.askForDiscordCredentials()
 		}

--- a/packages/create-robo/src/index.ts
+++ b/packages/create-robo/src/index.ts
@@ -225,7 +225,7 @@ new Command('create-robo <projectName>')
 		}
 
 		// Ask the user for their Discord credentials (token and client ID) and store them for later use
-		// Skip this step if the user is creating a plugin
+		// Skip this step if the user is creating a plugin or using web kit
 		if (!robo.isPlugin && options.kit !== 'web') {
 			logger.debug(`Asking for Discord credentials...`)
 			await robo.askForDiscordCredentials()


### PR DESCRIPTION
resolve #318