### PR TITLE
fix(create-robo/templates): remove `typeRoots` property to prevent interference with default ts behavior

### DIFF
--- a/packages/create-robo/src/env.ts
+++ b/packages/create-robo/src/env.ts
@@ -130,33 +130,6 @@ export class Env {
 			// Write env.d.ts
 			const envDtsPath = path.join(this.basePath, 'env.d.ts')
 			await fs.writeFile(envDtsPath, autoCompletionEnvVar, 'utf-8')
-
-			// Modify tsconfig.json if it exists
-			const tsconfigPath = path.join(this.basePath, 'tsconfig.json')
-			const tsconfigExists = await fs
-				.access(tsconfigPath)
-				.then(() => true)
-				.catch(() => false)
-
-			if (tsconfigExists) {
-				const tsconfigContent = await fs.readFile(tsconfigPath, 'utf-8')
-				const tsconfig = JSON.parse(tsconfigContent)
-				const compilerOptions = tsconfig.compilerOptions || {}
-
-				// Update typeRoots
-				let typeRoots: string[] = compilerOptions.typeRoots || []
-				if (!Array.isArray(typeRoots)) {
-					typeRoots = [typeRoots]
-				}
-				if (!typeRoots.includes('./env.d.ts')) {
-					typeRoots.push('./env.d.ts')
-				}
-				compilerOptions.typeRoots = typeRoots
-				tsconfig.compilerOptions = compilerOptions
-
-				// Write updated tsconfig.json
-				await fs.writeFile(tsconfigPath, JSON.stringify(tsconfig, null, 2), 'utf-8')
-			}
 		}
 	}
 

--- a/packages/create-robo/templates/app-ts-react/tsconfig.json
+++ b/packages/create-robo/templates/app-ts-react/tsconfig.json
@@ -9,7 +9,6 @@
 		"module": "esnext",
 		"useDefineForClassFields": true,
 		"incremental": true,
-		"typeRoots": ["./env.d.ts"],
 		"moduleResolution": "bundler",
 		"allowImportingTsExtensions": true,
 		"resolveJsonModule": true,

--- a/packages/create-robo/templates/app-ts/tsconfig.json
+++ b/packages/create-robo/templates/app-ts/tsconfig.json
@@ -9,7 +9,6 @@
 		"module": "esnext",
 		"useDefineForClassFields": true,
 		"incremental": true,
-		"typeRoots": ["./env.d.ts"],
 		"moduleResolution": "bundler",
 		"allowImportingTsExtensions": true,
 		"resolveJsonModule": true,

--- a/packages/create-robo/templates/webapp-ts-react/tsconfig.json
+++ b/packages/create-robo/templates/webapp-ts-react/tsconfig.json
@@ -9,7 +9,6 @@
 		"module": "esnext",
 		"useDefineForClassFields": true,
 		"incremental": true,
-		"typeRoots": ["./env.d.ts"],
 		"moduleResolution": "bundler",
 		"allowImportingTsExtensions": true,
 		"resolveJsonModule": true,

--- a/templates/discord-activities/react-colyseus-ts/tsconfig.json
+++ b/templates/discord-activities/react-colyseus-ts/tsconfig.json
@@ -9,7 +9,6 @@
 		"module": "esnext",
 		"useDefineForClassFields": false,
 		"incremental": true,
-		"typeRoots": ["./env.d.ts"],
 		"experimentalDecorators": true,
 		"moduleResolution": "bundler",
 		"allowImportingTsExtensions": true,

--- a/templates/discord-activities/react-multiplayer-video-ts/tsconfig.json
+++ b/templates/discord-activities/react-multiplayer-video-ts/tsconfig.json
@@ -13,9 +13,6 @@
 		"module": "esnext",
 		"useDefineForClassFields": true,
 		"incremental": true,
-		"typeRoots": [
-			"./env.d.ts"
-		],
 		"moduleResolution": "bundler",
 		"allowImportingTsExtensions": true,
 		"resolveJsonModule": true,

--- a/templates/discord-activities/react-music-proxy-ts/tsconfig.json
+++ b/templates/discord-activities/react-music-proxy-ts/tsconfig.json
@@ -13,9 +13,6 @@
 		"module": "esnext",
 		"useDefineForClassFields": true,
 		"incremental": true,
-		"typeRoots": [
-			"./env.d.ts"
-		],
 		"moduleResolution": "bundler",
 		"allowImportingTsExtensions": true,
 		"resolveJsonModule": true,

--- a/templates/discord-activities/react-tailwind-shadcn-ts/tsconfig.json
+++ b/templates/discord-activities/react-tailwind-shadcn-ts/tsconfig.json
@@ -9,7 +9,6 @@
 		"module": "esnext",
 		"useDefineForClassFields": true,
 		"incremental": true,
-		"typeRoots": ["./env.d.ts"],
 		"moduleResolution": "bundler",
 		"allowImportingTsExtensions": true,
 		"resolveJsonModule": true,

--- a/templates/discord-activities/react-tailwind-ts/tsconfig.json
+++ b/templates/discord-activities/react-tailwind-ts/tsconfig.json
@@ -9,7 +9,6 @@
 		"module": "esnext",
 		"useDefineForClassFields": true,
 		"incremental": true,
-		"typeRoots": ["./env.d.ts"],
 		"moduleResolution": "bundler",
 		"allowImportingTsExtensions": true,
 		"resolveJsonModule": true,

--- a/templates/discord-activities/react-trpc-ts/tsconfig.json
+++ b/templates/discord-activities/react-trpc-ts/tsconfig.json
@@ -13,9 +13,6 @@
 		"module": "esnext",
 		"useDefineForClassFields": true,
 		"incremental": true,
-		"typeRoots": [
-			"./env.d.ts"
-		],
 		"moduleResolution": "bundler",
 		"allowImportingTsExtensions": true,
 		"resolveJsonModule": true,

--- a/templates/discord-activities/react-ts/tsconfig.json
+++ b/templates/discord-activities/react-ts/tsconfig.json
@@ -9,7 +9,6 @@
 		"module": "esnext",
 		"useDefineForClassFields": true,
 		"incremental": true,
-		"typeRoots": ["./env.d.ts"],
 		"moduleResolution": "bundler",
 		"allowImportingTsExtensions": true,
 		"resolveJsonModule": true,

--- a/templates/discord-activities/unity/tsconfig.json
+++ b/templates/discord-activities/unity/tsconfig.json
@@ -13,9 +13,6 @@
     "module": "esnext",
     "useDefineForClassFields": true,
     "incremental": true,
-    "typeRoots": [
-      "./env.d.ts"
-    ],
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,

--- a/templates/discord-activities/vanilla-ts/tsconfig.json
+++ b/templates/discord-activities/vanilla-ts/tsconfig.json
@@ -9,7 +9,6 @@
 		"module": "esnext",
 		"useDefineForClassFields": true,
 		"incremental": true,
-		"typeRoots": ["./env.d.ts"],
 		"moduleResolution": "bundler",
 		"allowImportingTsExtensions": true,
 		"resolveJsonModule": true,

--- a/templates/discord-bots/analytics-ts/tsconfig.json
+++ b/templates/discord-bots/analytics-ts/tsconfig.json
@@ -13,10 +13,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "incremental": true,
-    "typeRoots": [
-      "./env.d.ts"
-    ]
+    "incremental": true
   },
   "include": [
     "**/*.ts"

--- a/templates/discord-bots/mongodb-ts/tsconfig.json
+++ b/templates/discord-bots/mongodb-ts/tsconfig.json
@@ -13,10 +13,7 @@
 		"moduleResolution": "node",
 		"resolveJsonModule": true,
 		"isolatedModules": true,
-		"incremental": true,
-		"typeRoots": [
-			"./env.d.ts"
-		]
+		"incremental": true
 	},
 	"include": [
 		"**/*.ts"

--- a/templates/discord-bots/mrjawesome-dev-toolkit-ts/tsconfig.json
+++ b/templates/discord-bots/mrjawesome-dev-toolkit-ts/tsconfig.json
@@ -13,10 +13,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "incremental": true,
-    "typeRoots": [
-      "./env.d.ts"
-    ]
+    "incremental": true
   },
   "include": [
     "**/*.ts"

--- a/templates/discord-bots/mrjawesome-slash-commands-ts/tsconfig.json
+++ b/templates/discord-bots/mrjawesome-slash-commands-ts/tsconfig.json
@@ -13,10 +13,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "incremental": true,
-    "typeRoots": [
-      "./env.d.ts"
-    ]
+    "incremental": true
   },
   "include": [
     "**/*.ts"

--- a/templates/discord-bots/postgres-ts/tsconfig.json
+++ b/templates/discord-bots/postgres-ts/tsconfig.json
@@ -11,8 +11,7 @@
 		"moduleResolution": "node",
 		"resolveJsonModule": true,
 		"isolatedModules": true,
-		"incremental": true,
-		"typeRoots": ["./env.d.ts"]
+		"incremental": true
 	},
 	"include": ["**/*.ts"],
 	"exclude": ["node_modules"]

--- a/templates/discord-bots/prisma-ts/tsconfig.json
+++ b/templates/discord-bots/prisma-ts/tsconfig.json
@@ -11,8 +11,7 @@
 		"moduleResolution": "node",
 		"resolveJsonModule": true,
 		"isolatedModules": true,
-		"incremental": true,
-		"typeRoots": ["./env.d.ts"]
+		"incremental": true
 	},
 	"include": ["**/*.ts"],
 	"exclude": ["node_modules"]

--- a/templates/discord-bots/purrth-vader-ts/tsconfig.json
+++ b/templates/discord-bots/purrth-vader-ts/tsconfig.json
@@ -13,10 +13,7 @@
 		"moduleResolution": "node",
 		"resolveJsonModule": true,
 		"isolatedModules": true,
-		"incremental": true,
-		"typeRoots": [
-			"./env.d.ts"
-		]
+		"incremental": true
 	},
 	"include": [
 		"**/*.ts"

--- a/templates/discord-bots/starter-ts/tsconfig.json
+++ b/templates/discord-bots/starter-ts/tsconfig.json
@@ -11,8 +11,7 @@
 		"moduleResolution": "node",
 		"resolveJsonModule": true,
 		"isolatedModules": true,
-		"incremental": true,
-		"typeRoots": ["./env.d.ts"]
+		"incremental": true
 	},
 	"include": ["**/*.ts"],
 	"exclude": ["node_modules"]

--- a/templates/web-apps/react-ts/tsconfig.json
+++ b/templates/web-apps/react-ts/tsconfig.json
@@ -13,9 +13,6 @@
 		"module": "esnext",
 		"useDefineForClassFields": true,
 		"incremental": true,
-		"typeRoots": [
-			"./env.d.ts"
-		],
 		"moduleResolution": "bundler",
 		"allowImportingTsExtensions": true,
 		"resolveJsonModule": true,


### PR DESCRIPTION
Closes #341 

### Summary

This pr removes the `typeRoots` property from all typescript projects created from robo.

### Changes

- Removed code related to inserting/updating `typeRoots`
- Removed code related to inserting/updating `compilerOptions` _(since this was only being used for the above? ^)_
- Manually removed all `typeRoots` property from `tsconfig.json` files in create-robo, activities and bot templates.