### PR TITLE
fix(robo): Getting the custom build directory on start command

### DIFF
--- a/packages/robo/src/cli/commands/start.ts
+++ b/packages/robo/src/cli/commands/start.ts
@@ -55,17 +55,6 @@ async function startAction(_args: string[], options: StartCommandOptions) {
 	logger.log(Indent, '   Boop beep... Powering on your Robo creation! Need hosting? Check out RoboPlay!')
 	logger.log('')
 
-	// Check if .robo/build directory has .js files (recursively)
-	if (!(await hasFilesRecursively(path.join('.robo', 'build')))) {
-		logger.error(
-			`No production build found. Make sure to compile your Robo using ${composeColors(
-				color.bold,
-				color.blue
-			)('"robo build"')} first.`
-		)
-		process.exit(1)
-	}
-
 	// Check if .robo/manifest.json is missing
 	try {
 		await fs.access(path.join('.robo', 'manifest.json'))
@@ -78,6 +67,7 @@ async function startAction(_args: string[], options: StartCommandOptions) {
 		)
 		process.exit(1)
 	}
+	
 
 	// Experimental warning, except for the disableBot flag which is a special case
 	const config = await loadConfig()
@@ -89,6 +79,21 @@ async function startAction(_args: string[], options: StartCommandOptions) {
 	if (experimentalKeys.length > 0) {
 		const features = experimentalKeys.map((key) => color.bold(key)).join(', ')
 		logger.warn(`Experimental flags enabled: ${features}.`)
+	}
+
+	// Check if the User has a custom build directory else set the default
+	const buildDirectory = config.experimental?.buildDirectory ?? path.join('.robo', 'build')
+
+
+	// Check if .robo/build directory has .js files (recursively)
+	if (!(await hasFilesRecursively(path.join(buildDirectory)))) {
+		logger.error(
+			`No production build found. Make sure to compile your Robo using ${composeColors(
+				color.bold,
+				color.blue
+			)('"robo build"')} first.`
+		)
+		process.exit(1)
 	}
 
 	// Start Roboooooooo!! :D (dynamic to avoid premature process hooks)


### PR DESCRIPTION
I fixed the issue, that it gives a build error when a user has set a custom build directory. But please test it again because I'm not sure if I tested the package correctly localy.