### PR TITLE
fix(env.ts): no need of double double quotes

### DIFF
--- a/.changeset/strong-hats-rescue.md
+++ b/.changeset/strong-hats-rescue.md
@@ -1,0 +1,5 @@
+---
+'create-robo': patch
+---
+
+fix: no need of double double quotes

--- a/packages/create-robo/src/env.ts
+++ b/packages/create-robo/src/env.ts
@@ -135,14 +135,7 @@ export class Env {
 
 	private escapeValue(value: string): string {
 		// Escape backslashes and double quotes
-		const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
-
-		// Determine if the value needs to be quoted
-		if (/[\s#=]/.test(value)) {
-			return `"${escaped}"`
-		} else {
-			return escaped
-		}
+		return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
 	}
 
 	/**


### PR DESCRIPTION
resolve #370 

its adding double double quote 

either we need to remove double quotes from here (1)

https://github.com/Wave-Play/robo.js/blob/7367cc61123ffd9c51f5588bb7c11a5d3776cb0d/packages/create-robo/src/env.ts#L113

or from here (2)

https://github.com/Wave-Play/robo.js/blob/7367cc61123ffd9c51f5588bb7c11a5d3776cb0d/packages/create-robo/src/env.ts#L141-L145

as they both are overlapping

its better to remove from (2) so to prevent this

```env
# Enable source maps for easier debugging
NODE_OPTIONS=--enable-source-maps
```
(im guessing this is invalid syntax for env file, or if IT IS valid, its better to remove double quotes from (1) **kindly suggest me**