### PR TITLE
fix(runtime): decouple Bun runtime from PM detection

### DIFF
--- a/.changeset/nervous-pumpkins-shop.md
+++ b/.changeset/nervous-pumpkins-shop.md
@@ -1,0 +1,5 @@
+---
+'robo.js': patch
+---
+
+fix(runtime): decouple Bun runtime from PM detection

--- a/.changeset/quiet-comics-compare.md
+++ b/.changeset/quiet-comics-compare.md
@@ -1,0 +1,5 @@
+---
+'create-robo': patch
+---
+
+refactor: change how it handles runtime detection + minor stuff

--- a/packages/@robojs/cron/src/core/cron.ts
+++ b/packages/@robojs/cron/src/core/cron.ts
@@ -1,5 +1,5 @@
 import { cronLogger } from './loggers.js'
-import { IS_BUN } from './utils.js'
+import { IS_BUN_RUNTIME } from './utils.js'
 import fs from 'node:fs'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -34,7 +34,7 @@ class CronJob {
 			let absolutePath = path.resolve(path.join(process.cwd(), '.robo', 'build', jobPath))
 			cronLogger.debug(`Executing cron job handler: ${color.bold(jobPath)}`)
 
-			if (!fs.existsSync(absolutePath) && absolutePath.endsWith('.js') && IS_BUN) {
+			if (!fs.existsSync(absolutePath) && absolutePath.endsWith('.js') && IS_BUN_RUNTIME) {
 				absolutePath = absolutePath.replace(/\.js$/, '.ts')
 			}
 

--- a/packages/@robojs/cron/src/core/utils.ts
+++ b/packages/@robojs/cron/src/core/utils.ts
@@ -14,4 +14,5 @@ export function getPackageManager(): PackageManager {
 	}
 }
 
-export const IS_BUN = getPackageManager() === 'bun'
+export const IS_BUN_PM = getPackageManager() === 'bun'
+export const IS_BUN_RUNTIME = process.versions.bun

--- a/packages/create-robo/src/index.ts
+++ b/packages/create-robo/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { Highlight, HighlightBlue, HighlightGreen, HighlightMagenta, HighlightRed, Indent } from './core/constants.js'
 import Robo from './robo.js'
-import { getPackageManager, packageJson } from './utils.js'
+import { IS_BUN_RUNTIME, getPackageManager, packageJson } from './utils.js'
 import path from 'node:path'
 import { input, select } from '@inquirer/prompts'
 import { color, logger } from 'robo.js'
@@ -232,7 +232,9 @@ new Command('create-robo <projectName>')
 		}
 
 		// Bun is special
-		if (getPackageManager() === 'bun') {
+		// if executed with with `bunx --bun create-robo`
+		// it will use it as runtime, hence:
+		if (IS_BUN_RUNTIME) {
 			await robo.bun()
 		}
 

--- a/packages/create-robo/src/robo.ts
+++ b/packages/create-robo/src/robo.ts
@@ -1058,16 +1058,16 @@ export default class Robo {
 
 	/**
 	 * Bun is special. Bun is love. Bun is life.
-	 * Bun requires `bunx --bun ` as a prefix before every `robo` and `sage` command.
+	 * Bun requires `bun --bun` as a prefix before every `robo` and `sage` command.
 	 */
 	public async bun(): Promise<void> {
-		// Go over every script in the package.json and add `bunx --bun ` before it
+		// Go over every script in the package.json and add `bun --bun ` before it
 		const scripts = Object.entries(this._packageJson.scripts)
 		logger.debug(`Adapting ${scripts.length} scripts for Bun...`)
 
 		for (const [key, value] of scripts) {
 			if (value.startsWith('robo') || value.startsWith('sage')) {
-				this._packageJson.scripts[key] = `bunx --bun ${value}`
+				this._packageJson.scripts[key] = `bun --bun ${value}`
 			}
 		}
 

--- a/packages/create-robo/src/utils.ts
+++ b/packages/create-robo/src/utils.ts
@@ -146,6 +146,8 @@ export function getPackageManager(): PackageManager {
 	}
 }
 
+export const IS_BUN_RUNTIME = process.versions.bun
+
 export function getPackageExecutor(): string {
 	const packageManager = getPackageManager()
 	if (packageManager === 'yarn') {

--- a/packages/plugin-api/src/core/runtime-utils.ts
+++ b/packages/plugin-api/src/core/runtime-utils.ts
@@ -37,7 +37,8 @@ export function getPackageExecutor(): string {
 	}
 }
 
-export const IS_BUN = getPackageManager() === 'bun'
+export const IS_BUN_PM = getPackageManager() === 'bun'
+export const IS_BUN_RUNTIME = process.versions.bun
 
 /**
  * Reads the package.json file and returns whether the given dependency is installed.

--- a/packages/robo/src/cli/commands/build/index.ts
+++ b/packages/robo/src/cli/commands/build/index.ts
@@ -13,8 +13,7 @@ import { Compiler } from '../../utils/compiler.js'
 import { Flashcore, prepareFlashcore } from '../../../core/flashcore.js'
 import { bold, color } from '../../../core/color.js'
 import { buildPublicDirectory } from '../../utils/public.js'
-import { discordLogger, FLASHCORE_KEYS, Highlight } from '../../../core/constants.js'
-import { IS_BUN } from '../../utils/runtime-utils.js'
+import { discordLogger, FLASHCORE_KEYS } from '../../../core/constants.js'
 import type { LoggerOptions } from '../../../core/logger.js'
 
 const command = new Command('build')
@@ -53,15 +52,6 @@ export async function buildAction(files: string[], options: BuildCommandOptions)
 	logger.debug('CLI options:', options)
 	logger.debug(`Current working directory:`, process.cwd())
 	const startTime = Date.now()
-
-	// Check for `bunx --bun` to ensure Bun is being used correctly
-	// @ts-expect-error - Bun is a global variable
-	if (IS_BUN && typeof Bun === "undefined") {
-		const command = '> bunx --bun robo ' + process.argv.slice(2).join(' ')
-		logger.error(`Please use "bunx --bun" to use Bun.`)
-		logger.error(Highlight(command), '\n')
-		process.exit(1)
-	}
 
 	// Make sure the user isn't trying to watch builds
 	// This only makes sense for plugins anyway

--- a/packages/robo/src/cli/utils/compiler.ts
+++ b/packages/robo/src/cli/utils/compiler.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import { copyDir, hasProperties, replaceSrcWithBuildInRecord } from './utils.js'
 import { logger } from '../../core/logger.js'
 import { env } from '../../core/env.js'
-import { IS_BUN } from './runtime-utils.js'
+import { IS_BUN_RUNTIME } from './runtime-utils.js'
 import { getManifest, useManifest } from '../compiler/manifest.js'
 import { buildSeed, hasSeed, useSeed } from '../compiler/seed.js'
 import { buildDeclarationFiles, getTypeScriptCompilerOptions, isTypescriptProject } from '../compiler/typescript.js'
@@ -21,7 +21,7 @@ async function preloadTypescript() {
 	try {
 		// Disable Typescript compiler(s) if using Bun, unless for plugin builds
 		// This is because plugins may be used in any runtime environment (not just Bun)
-		if (!IS_BUN) {
+		if (!IS_BUN_RUNTIME) {
 			logger.debug(`Preloading Typescript compilers...`)
 			const [typescript, swc] = await Promise.all([import('typescript'), import('@swc/core')])
 			ts = typescript.default
@@ -162,7 +162,7 @@ async function buildCode(options?: BuildCodeOptions) {
 		: path.join(process.cwd(), '.robo', 'build')
 
 	// Force load compilers for Bun in plugin builds
-	if (IS_BUN && options?.plugin) {
+	if (IS_BUN_RUNTIME && options?.plugin) {
 		await preloadTypescript()
 	}
 

--- a/packages/robo/src/cli/utils/manifest.ts
+++ b/packages/robo/src/cli/utils/manifest.ts
@@ -23,7 +23,7 @@ import { bold, color } from '../../core/color.js'
 import { ALLOWED_EXTENSIONS } from '../../core/constants.js'
 import { Mode } from '../../core/mode.js'
 import { Compiler } from './compiler.js'
-import { IS_BUN } from './runtime-utils.js'
+import { IS_BUN_RUNTIME } from './runtime-utils.js'
 import type { PermissionsString } from 'discord.js'
 
 // TODO:
@@ -446,7 +446,7 @@ async function generateEntries<T>(
 				logger.debug(`[${type}] Generating`, fileKeys, 'from', fullPath)
 				const isGenerated = generatedKeys.includes(fileKeys.join('/'))
 				let importPath = pathToFileURL(fullPath).toString()
-				if (IS_BUN) {
+				if (IS_BUN_RUNTIME) {
 					importPath = decodeURIComponent(importPath)
 				}
 				const module = await import(importPath)

--- a/packages/robo/src/cli/utils/runtime-utils.ts
+++ b/packages/robo/src/cli/utils/runtime-utils.ts
@@ -58,4 +58,5 @@ export async function hasDependency(name: string, dev = false): Promise<boolean>
 	}
 }
 
-export const IS_BUN = getPackageManager() === 'bun'
+export const IS_BUN_PM = getPackageManager() === 'bun'
+export const IS_BUN_RUNTIME = process.versions.bun

--- a/packages/robo/src/cli/utils/utils.ts
+++ b/packages/robo/src/cli/utils/utils.ts
@@ -10,7 +10,7 @@ import { logger } from '../../core/logger.js'
 import path from 'node:path'
 import os from 'node:os'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import { IS_BUN } from './runtime-utils.js'
+import { IS_BUN_PM } from './runtime-utils.js'
 import type { Pod } from '../../roboplay/types.js'
 import { existsSync } from 'node:fs'
 
@@ -211,7 +211,7 @@ export async function findPackagePath(packageName: string, currentPath: string):
 
 	let packagePath: string | null = null
 
-	if (isPnpmModules && !IS_BUN) {
+	if (isPnpmModules && !IS_BUN_PM) {
 		logger.debug(`Found pnpm node_modules folder for ${packageName}`)
 		try {
 			const { stdout } = await execAsync(`pnpm list ${packageName} --json`, { cwd: currentPath })

--- a/packages/robo/src/core/constants.ts
+++ b/packages/robo/src/core/constants.ts
@@ -1,6 +1,6 @@
 import { color, composeColors } from './color.js'
 import { logger } from './logger.js'
-import { IS_BUN } from '../cli/utils/runtime-utils.js'
+import { IS_BUN_RUNTIME } from '../cli/utils/runtime-utils.js'
 import type { Config } from '../types/index.js'
 
 export const Highlight = composeColors(color.bold, color.cyan)
@@ -12,7 +12,7 @@ export const cloudflareLogger = logger.fork('cloudflare')
 export const discordLogger = logger.fork('discord')
 
 // TODO: Test support for ['.js', '.jsx', '.ts', '.tsx'] in Bun
-export const ALLOWED_EXTENSIONS = IS_BUN ? ['.js', '.jsx', '.ts', '.tsx'] : ['.js', '.jsx']
+export const ALLOWED_EXTENSIONS = IS_BUN_RUNTIME ? ['.js', '.jsx', '.ts', '.tsx'] : ['.js', '.jsx']
 
 export const DEFAULT_CONFIG: Config = {
 	clientOptions: null,

--- a/packages/robo/src/core/env.ts
+++ b/packages/robo/src/core/env.ts
@@ -1,4 +1,4 @@
-import { IS_BUN } from '../cli/utils/runtime-utils.js'
+import { IS_BUN_RUNTIME } from '../cli/utils/runtime-utils.js'
 import { logger } from './logger.js'
 import { existsSync, readFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
@@ -246,7 +246,7 @@ function applyEnv(options: LoadOptions, newEnvVars: Record<string, string>) {
 
 function getFilePath(options: LoadOptions): string | null {
 	// No need to load .env file if using Bun (it's already loaded)
-	if (IS_BUN) {
+	if (IS_BUN_RUNTIME) {
 		return null
 	}
 


### PR DESCRIPTION
Closes #377 

### Changes
- Split ambiguous `IS_BUN` constant into two distinct ones:
  - `IS_BUN_RUNTIME`: Specifically for runtime environment checks _([see ref](https://bun.sh/guides/util/detect-bun))_
  - `IS_BUN_PM`: For package manager related operations
- Assigned and replaced the respective checks depending on wether it was actually needing a check for Runtime or PM.
- Removed code block that forced `bunx --bun` requirement when it detected Bun (either as PM or Runtime)
- Maintained existing functionality while providing more flexibility
- Changed `scripts` mapping when using Bun
  - Replaced `bunx --bun` in favor of `bun --bun`
  - `bunx` will fallback to global/remote dependencies if no local ones are found, this may lead to unexpected issues in dev & prod.

#### Expected behavior
```bash
# Before: Would force Bun runtime
bun dev  # Would error without `bunx --bun` in the script.

# After: Flexible runtime choice
bun dev # Uses Bun's task runner and Node runtime (shebang needed on Robo's side)
bun --bun dev  # Uses Bun runtime
```

### Checks
- [x] Test Robo with changes
- [x] Tested Bun as package manager with Node runtime
- [x] Verify it doesn't uses Bun as Runtime when it's intended to be PM/task manager only _([see ref](https://bun.sh/docs/cli/run#bun))_
- [x] Verify overall functionality remains intact
- [x] Verify whether we'll need manual shebang addition or not.
- [x] Test templates

### Notes

- Theoretically these changes will suffice, however, I'm not certain yet that Bun won't be used as a Runtime when using it as a task runner only.
  -  ^ Looking into this
- ^ Might need to add a shebang for Robo in order to safely use the runtime that's intended.

### Post-checks notes

- Been testing for a while and everything works as expected.
- Runtime and PM can now be mixed with no conflicts:
  - Node Runtime & Bun PM works.
  - Bun Runtime & NPM works _(idk who does this tho)_.
  - Node Runtime & NPM works.
  - Bun Runtime & Bun PM works.
  - Bun Runtime & PNPM works.
- Found that we actually use shebang that favors Node, so there's no risk about using the wrong runtime by accident.