### PR TITLE
Fix(sage/upgrade) option name

### DIFF
--- a/packages/sage/src/commands/upgrade.ts
+++ b/packages/sage/src/commands/upgrade.ts
@@ -23,7 +23,7 @@ const command = new Command('upgrade')
 export default command
 
 interface UpgradeOptions {
-	autoAccept?: boolean
+	yes?: boolean
 	force?: boolean
 	selfCheck?: boolean
 	silent?: boolean
@@ -58,7 +58,7 @@ async function upgradeAction(options: UpgradeOptions) {
 	const update = await checkUpdates(packageJson, config, true)
 	logger.debug(`Update payload:`, update)
 
-	await updateRobo(plugins, config, options.autoAccept)
+	await updateRobo(plugins, config, options.yes)
 }
 
 interface Changelog {

--- a/packages/sage/src/commands/upgrade.ts
+++ b/packages/sage/src/commands/upgrade.ts
@@ -58,7 +58,8 @@ async function upgradeAction(options: UpgradeOptions) {
 	const update = await checkUpdates(packageJson, config, true)
 	logger.debug(`Update payload:`, update)
 
-	await updateRobo(plugins, config, options.yes)
+	const autoAccept = options.yes
+	await updateRobo(plugins, config, autoAccept)
 }
 
 interface Changelog {


### PR DESCRIPTION
Please accept and merge this as I have introduced a bug in the previous one, the type inference was not done properly and it introduced autoAccept instead of yes in the command options when parsed, this is wrong thus turning into code never being correctly ran, this fixes it, the option name as to be ```yes``` in the types.

Let me know if you think of a better way of doing it.