### PR TITLE
Fix error while having a response with null body

### DIFF
--- a/packages/plugin-api/src/core/handler.ts
+++ b/packages/plugin-api/src/core/handler.ts
@@ -66,22 +66,24 @@ export function createServerHandler(router: Router, vite?: ViteDevServer): Serve
 				this.raw.statusCode = response.status
 
 				// Stream the response body
-				const reader = response.body.getReader()
-				const read = async () => {
-					while (true) {
-						const { done, value } = await reader.read()
-
-						if (done) {
-							break
-						} else {
-							this.raw.write(value)
+				if (response.body !== null) {
+					const reader = response.body.getReader()
+					const read = async () => {
+						while (true) {
+							const { done, value } = await reader.read()
+							if (done) {
+								break
+							} else {
+								this.raw.write(value)
+							}
 						}
 					}
+					read().then(() => {
+						this.raw.end()
+					})
+				} else {
+					this.raw.end();
 				}
-
-				read().then(() => {
-					this.raw.end()
-				})
 
 				this.hasSent = true
 				return this


### PR DESCRIPTION
While having this implementation of a route, the server throws an error:
```ts
export default (): any => {
	return new Response(null, {
		status: 400,
	});
};
```
This is the error:
```
TypeError: Cannot read properties of null (reading 'getReader')
    at Object.send (file:///K:/GitHub/robo-base/node_modules/@robojs/server/.robo/build/core/handler.js:53:46)
    at NodeEngine._serverHandler (file:///K:/GitHub/robo-base/node_modules/@robojs/server/.robo/build/core/handler.js:119:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```
Also, note that the actual response returned to the client will go with a code 200 regardless of what was specified:
![image](https://github.com/user-attachments/assets/eaec6742-89e6-4262-9175-fbaf98ff01a7)

With this fix, the Response object can have a null body no problem.