### PR TITLE
chore: update type test

### DIFF
--- a/packages/@robojs/i18n/__typetests__/command-options.test.ts
+++ b/packages/@robojs/i18n/__typetests__/command-options.test.ts
@@ -25,7 +25,7 @@ describe('createCommandConfig — option name infers key', () => {
 		// has the property
 		expect<OptsOk>().type.toHaveProperty('text')
 		// property type is string | undefined
-		expect<OptsOk['text']>().type.toBe<string | undefined>()
+		expect<Pick<OptsOk, 'text'>>().type.toBe<{ text: string | undefined }>()
 		// should NOT have an unrelated property
 		expect<OptsOk>().type.not.toHaveProperty('missing')
 	})


### PR DESCRIPTION
Glad to see you found TSTyche useful. I am its author.

To test type of properties, I would suggested `Pick` utility instead of bracket notation ([playground](https://www.typescriptlang.org/play/?exactOptionalPropertyTypes=true#code/JYOwLgpgTgZghgYwgAgMpwLYAcA2KDeAsAFDJnJwBcyAzmFKAOYDcJ5yARgPzUgCuGDtFalyCHpwD2kvHBDIAPsj4gAJhBigIqkQF8SB4iTABPLCgCCARmQBeNJlwQA2gHI4rgLoiA9D-IAelzGZigAQjb26Nh4bhxezOxJySnkfsgA7lCSIIwANMjAYIU0yBhwUADWyJJYYMA5cDgFIJLFKuqaINok6WRBIebIAMKRDjEurggJvf79wUbEpkMWAEx2yAAKwAiVADzRTgXurgB8vnPIA0uhyGHr9tu7B454x-HnqV9k6SYQWAUcjgTDU6g0QE1MkUABaSPjtNQaLSqACEs0CC2WKGGDy2O32hzeyCmZwuGMMhixyAASmNqRA4KogSYXhNTnEEt8kulWuYWm1lIiuj1iH0rpjbtTcU99vTGczWU5Tu9SV90hAAB6IMDAgpQBlMkDAihqUH1Ro4NGiy7XIA)). As you see with `Pick` you have more information about the property (is it optional? is it readonly?) and it is precise with [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) too.