### PR TITLE
chore: refactor type tests

### DIFF
--- a/packages/@robojs/i18n/__typetests__/discord-commands.test.ts
+++ b/packages/@robojs/i18n/__typetests__/discord-commands.test.ts
@@ -18,7 +18,7 @@ describe('createCommandConfig — CommandOptions typing from options', () => {
 		} as const)
 
 		type Opts = CommandOptions<typeof cfg>
-        expect<Opts>().type.toHaveProperty('text')
+		expect<Opts>().type.toHaveProperty('text')
 		expect<Pick<Opts, 'text'>>().type.toBe<{ text: string | undefined }>()
 	})
 
@@ -41,7 +41,7 @@ describe('createCommandConfig — CommandOptions typing from options', () => {
 		expect<Opts>().type.toHaveProperty('text')
 		type TextVal = Pick<Opts, 'text'>
 		expect<TextVal>().type.toBe<{ text: string }>()
-		expect<undefined>().type.not.toBeAssignableTo<TextVal>()
+		expect<TextVal>().type.not.toBeAssignableWith<undefined>()
 		expect<Opts>().type.not.toHaveProperty('missing')
 	})
 

--- a/packages/@robojs/i18n/__typetests__/keys.test.ts
+++ b/packages/@robojs/i18n/__typetests__/keys.test.ts
@@ -3,19 +3,19 @@ import type { LocaleKey } from '../.robo/generated/types'
 
 describe('LocaleKey coverage', () => {
 	test('Known keys exist', () => {
-		expect<'shared/common:hello'>().type.toBeAssignableTo<LocaleKey>()
-		expect<'shared/common:pets.count'>().type.toBeAssignableTo<LocaleKey>()
-		expect<'shared/common:when.run'>().type.toBeAssignableTo<LocaleKey>()
-		expect<'shared/common:array'>().type.toBeAssignableTo<LocaleKey>()
-		expect<'commands:hey'>().type.toBeAssignableTo<LocaleKey>()
-		expect<'commands:ping.name'>().type.toBeAssignableTo<LocaleKey>()
-		expect<'commands:ping.desc'>().type.toBeAssignableTo<LocaleKey>()
-		expect<'commands:ping.arg.name'>().type.toBeAssignableTo<LocaleKey>()
-		expect<'commands:ping.arg.desc'>().type.toBeAssignableTo<LocaleKey>()
+		expect<LocaleKey>().type.toBeAssignableWith<'shared/common:hello'>()
+		expect<LocaleKey>().type.toBeAssignableWith<'shared/common:pets.count'>()
+		expect<LocaleKey>().type.toBeAssignableWith<'shared/common:when.run'>()
+		expect<LocaleKey>().type.toBeAssignableWith<'shared/common:array'>()
+		expect<LocaleKey>().type.toBeAssignableWith<'commands:hey'>()
+		expect<LocaleKey>().type.toBeAssignableWith<'commands:ping.name'>()
+		expect<LocaleKey>().type.toBeAssignableWith<'commands:ping.desc'>()
+		expect<LocaleKey>().type.toBeAssignableWith<'commands:ping.arg.name'>()
+		expect<LocaleKey>().type.toBeAssignableWith<'commands:ping.arg.desc'>()
 	})
 
 	test('Unknown keys are not present', () => {
-		expect<'shared/common:missing'>().type.not.toBeAssignableTo<LocaleKey>()
-		expect<'foo:bar'>().type.not.toBeAssignableTo<LocaleKey>()
+		expect<LocaleKey>().type.not.toBeAssignableWith<'shared/common:missing'>()
+		expect<LocaleKey>().type.not.toBeAssignableWith<'foo:bar'>()
 	})
 })

--- a/packages/@robojs/i18n/__typetests__/locales.test.ts
+++ b/packages/@robojs/i18n/__typetests__/locales.test.ts
@@ -4,22 +4,22 @@ import type { LocaleLike } from '../.robo/build/core/types'
 
 describe('Locales & LocaleLike', () => {
 	test('Locale includes shipped tags', () => {
-		expect<'en-US'>().type.toBeAssignableTo<Locale>()
-		expect<'es-ES'>().type.toBeAssignableTo<Locale>()
-		expect<'fr'>().type.toBeAssignableTo<Locale>()
+		expect<Locale>().type.toBeAssignableWith<'en-US'>()
+		expect<Locale>().type.toBeAssignableWith<'es-ES'>()
+		expect<Locale>().type.toBeAssignableWith<'fr'>()
 	})
 
 	test('Unknown plain string is not a Locale', () => {
-		expect<'de-DE'>().type.not.toBeAssignableTo<Locale>()
+		expect<Locale>().type.not.toBeAssignableWith<'de-DE'>()
 	})
 
 	test('LocaleLike accepts string or objects with locale/guildLocale', () => {
-		expect<'en-US'>().type.toBeAssignableTo<LocaleLike>()
-		expect<{ locale: 'en-US' }>().type.toBeAssignableTo<LocaleLike>()
-		expect<{ guildLocale: 'fr' }>().type.toBeAssignableTo<LocaleLike>()
+		expect<LocaleLike>().type.toBeAssignableWith<'en-US'>()
+		expect<LocaleLike>().type.toBeAssignableWith<{ locale: 'en-US' }>()
+		expect<LocaleLike>().type.toBeAssignableWith<{ guildLocale: 'fr' }>()
 	})
 
 	test('LocaleLike intentionally allows dynamic strings inside objects', () => {
-		expect<{ locale: 'de-DE' }>().type.toBeAssignableTo<LocaleLike>()
+		expect<LocaleLike>().type.toBeAssignableWith<{ locale: 'de-DE' }>()
 	})
 })

--- a/packages/@robojs/i18n/__typetests__/returns.test.ts
+++ b/packages/@robojs/i18n/__typetests__/returns.test.ts
@@ -10,9 +10,9 @@ describe('Return types (string vs string[])', () => {
 
 	test('t(): returns string for scalar keys; string[] for array keys', () => {
 		const a = t('en-US', 'shared/common:hello', { name: 'Robo', randomNumber: 7 })
-		expect<typeof a>().type.toBe<string>()
+		expect(a).type.toBe<string>()
 
 		const b = t('en-US', 'shared/common:array', { num: 1, date: Date.now() })
-		expect<typeof b>().type.toBe<string[]>()
+		expect(b).type.toBe<string[]>()
 	})
 })

--- a/packages/@robojs/i18n/__typetests__/runtime-apis.test.ts
+++ b/packages/@robojs/i18n/__typetests__/runtime-apis.test.ts
@@ -5,11 +5,11 @@ import type { MaybeArgs, StrictParamsFor } from '../.robo/build/core/types'
 describe('t() (loose) and tr() (strict) enforcement', () => {
 	test('t(): params optional but checked; excess props rejected (via excess property checks)', () => {
 		const ok1 = t('en-US', 'shared/common:hello', { name: 'X', randomNumber: 1 })
-		expect<typeof ok1>().type.toBe<string>()
+		expect(ok1).type.toBe<string>()
 
 		// Missing params is OK in loose mode (they’re optional types)
 		const ok2 = t('en-US', 'shared/common:hello')
-		expect<typeof ok2>().type.toBe<string>()
+		expect(ok2).type.toBe<string>()
 
 		// Excess property fails (object-literal excess property checks)
 		expect(t('en-US', 'shared/common:hello', { name: 'X', randomNumber: 2, oops: true })).type.toRaiseError()
@@ -23,7 +23,7 @@ describe('t() (loose) and tr() (strict) enforcement', () => {
 		expect(tr('en-US', 'shared/common:hello', { name: 'X' })).type.toRaiseError()
 		// Correct full shape OK
 		const ok = tr('en-US', 'shared/common:hello', { name: 'X', randomNumber: 42 })
-		expect<typeof ok>().type.toBe<string>()
+		expect(ok).type.toBe<string>()
 
 		// Date/time must be Date | number
 		expect(tr('en-US', 'shared/common:when.run', { ts: '2020-01-01' })).type.toRaiseError()
@@ -31,7 +31,7 @@ describe('t() (loose) and tr() (strict) enforcement', () => {
 
 	test('Keys with no params require none in strict mode', () => {
 		const ok = tr('en-US', 'commands:ping.name')
-		expect<typeof ok>().type.toBe<string>()
+		expect(ok).type.toBe<string>()
 
 		// Passing params for a no-param key should fail (excess property)
 		expect(tr('en-US', 'commands:ping.name', {} as StrictParamsFor<'commands:hey'>)).type.toRaiseError()
@@ -41,8 +41,8 @@ describe('t() (loose) and tr() (strict) enforcement', () => {
 		const t$ = withLocale('en-US')
 		const a = t$('shared/common:hello', { name: 'A', randomNumber: 1 })
 		const b = t$('shared/common:hello')
-		expect<typeof a>().type.toBe<string>()
-		expect<typeof b>().type.toBe<string>()
+		expect(a).type.toBe<string>()
+		expect(b).type.toBe<string>()
 
 		const tr$ = withLocale('en-US', { strict: true })
 		// Missing params → error (strict)
@@ -51,7 +51,7 @@ describe('t() (loose) and tr() (strict) enforcement', () => {
 		expect(tr$('commands:hey', { user: {} })).type.toRaiseError()
 		// Correct nested shape OK
 		const ok = tr$('commands:hey', { user: { name: 'Pk' } })
-		expect<typeof ok>().type.toBe<string>()
+		expect(ok).type.toBe<string>()
 	})
 
 	test('MaybeArgs<K> behavior', () => {


### PR DESCRIPTION
Thanks for a ping. The type tests you have added look very good.

This is just a minor refactor:

- there is no need to use `typeof`, `expect<typeof a>()` and `expect(a)` are equivalent;
- use `.toBeAssignableWith()` instead of `.toBeAssignableTo()`, they are equivalent only with `source` and `target` swapped.

My bad. I see that documentation states that `.toBeAssignableWith()` if the "opposite of the `.toBeAssignableTo()` matcher". That’s not correct. They are equivalent with `source` and `target` swapped. And the opposite behaviour comes from `.not`. I have to rework the docs.

`.toBeAssignableWith()` and `.toBeAssignableTo()` exist to allow keeping the type under test on the left hand side of the assertion. This improves readability:

```ts
expect<TextVal>().type.toBe<{ text: string }>()
expect<TextVal>().type.not.toBeAssignableWith<undefined>()
```

instead of:

```ts
expect<TextVal>().type.toBe<{ text: string }>()
expect<undefined>().type.not.toBeAssignableTo<TextVal>()
```

