### PR TITLE
fix(docs): keeping md extensions

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -34,6 +34,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "tailwind-merge": "^3.2.0",
+    "unist-util-visit": "^5.1.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -1,49 +1,50 @@
-import { remarkInstall } from "fumadocs-docgen"
-import { defineCollections, defineConfig, defineDocs, frontmatterSchema } from "fumadocs-mdx/config"
-import remarkReleaseTag from "./src/lib/remark-release-tag"
-import { z } from "zod"
+import { remarkInstall } from 'fumadocs-docgen'
+import { defineCollections, defineConfig, defineDocs, frontmatterSchema } from 'fumadocs-mdx/config'
+import remarkReleaseTag from './src/lib/remark-release-tag'
+import remarkStripMdxExt from './src/lib/remark-strip-mdx-ext'
+import { z } from 'zod'
 
 export const docs = defineDocs({
-  dir: "content/docs",
+	dir: 'content/docs'
 })
 
 export const blog = defineCollections({
-  type: "doc",
-  dir: "content/blog",
-  schema: frontmatterSchema.extend({
-    author: z.string(),
-    date: z.string().date().or(z.date()).optional(),
-  }),
+	type: 'doc',
+	dir: 'content/blog',
+	schema: frontmatterSchema.extend({
+		author: z.string(),
+		date: z.string().date().or(z.date()).optional()
+	})
 })
 
 const directorySchema = frontmatterSchema.extend({
-  author: z.string(),
-  sourceType: z.enum(["official", "community"]),
-  itemType: z.enum(["plugin", "template"]),
-  date: z.string().date().or(z.date()).optional(),
-  language: z.array(z.enum(["typescript", "javascript"])),
-  type: z.enum(["bot", "web", "activity", "plugin"]),
-  image: z.string().optional(),
-  stars: z.number().optional(),
+	author: z.string(),
+	sourceType: z.enum(['official', 'community']),
+	itemType: z.enum(['plugin', 'template']),
+	date: z.string().date().or(z.date()).optional(),
+	language: z.array(z.enum(['typescript', 'javascript'])),
+	type: z.enum(['bot', 'web', 'activity', 'plugin']),
+	image: z.string().optional(),
+	stars: z.number().optional()
 })
 
 export const directory = defineCollections({
-  type: "doc",
-  dir: "content/directory",
-  schema: directorySchema,
+	type: 'doc',
+	dir: 'content/directory',
+	schema: directorySchema
 })
 
 export type DirectoryItem = z.infer<typeof directorySchema>
 
 export default defineConfig({
-  mdxOptions: {
-    rehypeCodeOptions: {
-      inline: "tailing-curly-colon",
-      themes: {
-        dark: "vitesse-dark",
-        light: "vitesse-light",
-      },
-    },
-    remarkPlugins: [remarkReleaseTag, [remarkInstall, { persist: { id: "pkg-add-persist" } }]],
-  },
+	mdxOptions: {
+		rehypeCodeOptions: {
+			inline: 'tailing-curly-colon',
+			themes: {
+				dark: 'vitesse-dark',
+				light: 'vitesse-light'
+			}
+		},
+		remarkPlugins: [remarkStripMdxExt, remarkReleaseTag, [remarkInstall, { persist: { id: 'pkg-add-persist' } }]]
+	}
 })

--- a/docs/src/lib/remark-strip-mdx-ext.ts
+++ b/docs/src/lib/remark-strip-mdx-ext.ts
@@ -1,0 +1,11 @@
+import { visit } from 'unist-util-visit'
+import type { Root } from 'mdast'
+
+export default function remarkStripMdxExt() {
+	return (tree: Root) => {
+		visit(tree, 'link', (node: any) => {
+			if (typeof node.url !== 'string') return
+			node.url = node.url.replace(/\.mdx?(?=$|[?#])/, '')
+		})
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       tailwind-merge:
         specifier: ^3.2.0
         version: 3.2.0
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
       zod:
         specifier: ^4.0.0
         version: 4.0.0
@@ -4644,7 +4647,7 @@ packages:
       unified: 11.0.5
       unist-util-position-from-estree: 2.0.0
       unist-util-stringify-position: 4.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -6539,7 +6542,7 @@ packages:
       hast-util-to-string: 3.0.1
       shiki: 3.21.0
       unified: 11.0.5
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
     dev: false
 
   /@shikijs/themes@3.21.0:
@@ -10486,7 +10489,7 @@ packages:
       remark-rehype: 11.1.2
       scroll-into-view-if-needed: 3.1.0
       shiki: 3.21.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       zod: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -10555,7 +10558,7 @@ packages:
       remark-rehype: 11.1.2
       scroll-into-view-if-needed: 3.1.0
       shiki: 3.21.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       zod: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -10571,7 +10574,7 @@ packages:
       fumadocs-core: 16.3.2(@types/react@19.2.8)(lucide-react@0.503.0)(next@16.1.1)(react-dom@19.2.3)(react@19.2.3)(zod@4.0.0)
       npm-to-yarn: 3.0.1
       oxc-transform: 0.96.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       zod: 4.3.5
     dev: false
 
@@ -10615,7 +10618,7 @@ packages:
       tinyglobby: 0.2.15
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
       zod: 4.3.5
     transitivePeerDependencies:
@@ -13190,7 +13193,7 @@ packages:
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
       unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
     dev: false
 
@@ -13204,7 +13207,7 @@ packages:
       mdast-util-to-string: 4.0.0
       micromark-util-classify-character: 2.0.1
       micromark-util-decode-string: 2.0.1
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       zwitch: 2.0.4
     dev: false
 
@@ -16744,7 +16747,7 @@ packages:
     resolution: {integrity: sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==}
     dependencies:
       '@types/unist': 3.0.3
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
     dev: false
 
   /unist-util-stringify-position@4.0.0:
@@ -16759,8 +16762,8 @@ packages:
       unist-util-is: 6.0.1
     dev: false
 
-  /unist-util-visit@5.0.0:
-    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+  /unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1


### PR DESCRIPTION
Root cause:** The source files use relative links with explicit `.mdx` extensions (e.g. `[CORS](./cors.mdx)`). Fumadocs does **not** strip those by default — they pass through as literal URLs, and `/docs/server/cors.mdx` isn't a route so it 404s. The `.mdx` style is nice for IDE Ctrl+click, but needs a rewrite during MDX processing.

**Scope:** 63 broken links across 37 files — it's a config gap, not a content mistake.

I know I could have asked A.I to fix the broken links, but this seems a lot more reliable for now.